### PR TITLE
Fix broken seconds count

### DIFF
--- a/timer.py
+++ b/timer.py
@@ -12,7 +12,7 @@ def time_string(val):
     val = int(val)
     h = int(val / 60 / 60)
     m = int((val / 60) - (h * 60))
-    s = int(val - (m * 60))
+    s = int(val % 60)
     return (str(h)+"h" if h else "") + (str(m)+"m" if m else "") + str(s)+"s"
 
 


### PR DESCRIPTION
See e.g. today's results:

```
===> You marked 34 scripts in 8h32m28828s, with 4 pauses, mean 15m4s, max 49m5s, min 5m16s !!
```
A highly inappropriate number of seconds.